### PR TITLE
Remove generic redirection to login page

### DIFF
--- a/common/middleware/auth/middleware.py
+++ b/common/middleware/auth/middleware.py
@@ -19,18 +19,9 @@ class AuthRequiredMiddleware(object):
 
     def process_request(self, request):
         path = request.path_info.lstrip('/')
-        if not request.user.is_authenticated():
-            # Login check by conner.xyz (http://stackoverflow.com/users/2836259/conner-xyz)
-            # http://stackoverflow.com/a/40873794/2557554
-            # CC-BY-SA 3.0 (https://creativecommons.org/licenses/by-sa/3.0/deed.en)
-            if not any(path == eu for eu in ["", "login/",
-                                             "accounts/register/",
-                                             "accounts/password/reset/",
-                                             "admin/"]):
-                return redirect('%s?next=%s' % (settings.LOGIN_URL, request.path))  # or http response
-        else:
+        if request.user.is_authenticated():
             if any(path == eu for eu in ["accounts/register/"]):
-                return redirect('/')  # or http response
+                return redirect(reverse('index'))
 
             user_profile = Author.objects.get(user_id=request.user.id)
 


### PR DESCRIPTION
Hey @ookmm, based on our discussion, I've removed the generic authentication redirection so that all pages will be visible based on their own authentication specification. As such, you will have to secure specific endpoints with the authentication decorators. For example, please take a look at the [@login_required](https://docs.djangoproject.com/en/1.10/topics/auth/default/#the-login-required-decorator) decorator.