### PR TITLE
28 restful interface

### DIFF
--- a/service/serializers.py
+++ b/service/serializers.py
@@ -15,9 +15,9 @@ class UserSerializer(serializers.HyperlinkedModelSerializer):
 
 
 class AuthorSerializer(serializers.ModelSerializer):
-    github = serializers.URLField()
-    host = serializers.URLField()
-    url = serializers.URLField()
+    class Meta:
+        model = Author
+        fields = ('user', 'id', 'displayName', 'github', 'bio', 'activated', 'node', )
 
 
 class FriendRequestAuthorSerializer(serializers.Serializer):


### PR DESCRIPTION
@adamjford Was the `/authors/` endpoint working when you made your adjustments? Because it tells me that it's not correctly configured since the `Meta` class implementation is missing.