### PR TITLE
Can now view a particular author's posts

### DIFF
--- a/social/app/templates/app/includes/user_profile_posts.html
+++ b/social/app/templates/app/includes/user_profile_posts.html
@@ -1,12 +1,14 @@
 {% load staticfiles %}
 
 <div class="col-md-6">
-    <div class="row sd-margin-bottom-20">
-        <div class="col-sm-12">
-            <a class="btn btn-primary" href="{% url 'app:posts:posts-add' %}"><span
+    {% if show_add_post_button == "true" %}
+        <div class="row sd-margin-bottom-20">
+            <div class="col-sm-12">
+                <a class="btn btn-primary" href="{% url 'app:posts:posts-add' %}"><span
                     class="glyphicon glyphicon-pencil"></span> Add New Post</a>
+            </div>
         </div>
-    </div>
+    {% endif %}
     <div id="sd-profile-posts-wrapper">
         {% if user_posts %}
             <ol class="media-list">
@@ -17,7 +19,7 @@
                 {% endfor %}
             </ol>
         {% else %}
-            <p>You don't have any post</p>
+            <p>No posts here!</p>
         {% endif %}
     </div>
 </div>

--- a/social/app/urls.py
+++ b/social/app/urls.py
@@ -6,7 +6,6 @@ from social.app.views import friend as friend_views
 
 posts_urlpatterns = [
     # /posts/
-    # url(r'^$', views.IndexView.as_view(), name='index'),
     url(r'^$', post_views.view_posts, name='index'),
 
     # /posts/71/
@@ -31,8 +30,12 @@ posts_urlpatterns = [
 ]
 
 authors_urlpatterns = [
+    # /authors/
     url(r'^$', author_views.AuthorListView.as_view(), name='list'),
+    # /authors/aeea8619-a9c1-4792-a273-80ccb7255ea2/
     url(r'^(?P<pk>[0-9,a-z,\\-]+)$', author_views.AuthorDetailView.as_view(), name='detail'),
+    # /authors/aeea8619-a9c1-4792-a273-80ccb7255ea2/posts/
+    url(r'^(?P<pk>[0-9,a-z,\\-]+)/posts/$', author_views.view_posts_by_author, name='posts-by-author'),
 ]
 
 urlpatterns = [

--- a/social/templates/navigations/main.html
+++ b/social/templates/navigations/main.html
@@ -21,7 +21,7 @@
                        aria-expanded="false">{{ user.profile.displayName }}<span class="caret"></span></a>
 
                     <ul class="dropdown-menu">
-                        <li><a href="{% url 'app:dashboard' %}">My Posts</a></li>
+                        <li><a href="{% url 'app:authors:posts-by-author' user.profile.id  %}">My Posts</a></li>
                         <li><a href="{% url 'app:posts:index' %}">My Feed</a></li>
                         <li><a href="{% url 'app:friend-requests-list' %}">View Friend Requests</a></li>
                         <li><a href="{% url 'app:authors:list' %}">Find Authors</a></li>


### PR DESCRIPTION
Current state: Go to "Find Authors", click a listed author, then manually add "/posts/" to the end of the url.. ie:
/authors/5ec32f5e-8e5e-495f-b38e-3cf340d18b2c/**posts/**

If the current user is the author in that url, then they will see all of their posts (and be able to edit them). If the current user is not the author at that url, then they will see only the posts they have permission to view.

* I want to change main.html such that when you click the "My Posts" button it takes you to 
/authors/<my_guid>/posts/ but I'm not sure how to do that, so it left it as /dashboard/ for now. I'm finding this tricky because somehow you need to be able to form the url from the current user's corresponding author id. Any ideas would be appreciated.  


