### PR TITLE
Delete post bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,8 @@ Sources
   Danilo Bergen (http://stackoverflow.com/users/284318/danilo-bargen) 
   From http://stackoverflow.com/a/11189383/2557554 and licensed under 
   CC-BY-SA 3.0 (https://creativecommons.org/licenses/by-sa/3.0/deed.en)
+
+* How to pass argument to reverse
+  By igor(https://stackoverflow.com/users/978434/igor)
+  On StackOverflow url: https://stackoverflow.com/questions/15703475/how-to-make-reverse-lazy-lazy-for-arguments-too
+  License: CC-BY-SA 3.0

--- a/social/app/templates/posts/post_media/post_edit_dropdown.html
+++ b/social/app/templates/posts/post_media/post_edit_dropdown.html
@@ -15,11 +15,11 @@
             <!-- Delete posts -->
             <a type="submit"
                class="btn btn-block btn-fixed-corners"
-               onclick="$('#deletePostForm').submit();">
+               onclick="$('#post-{{ post.id }}').submit();">
                 <span class="glyphicon glyphicon-trash"></span>
                 Delete
             </a>
-            <form id="deletePostForm"
+            <form id="post-{{ post.id }}"
                   action="{% url 'app:posts:posts-delete' post.id %}"
                   method="post"
                   onsubmit="return confirm('Are you sure you want to delete your posts?');">

--- a/social/app/urls.py
+++ b/social/app/urls.py
@@ -21,7 +21,8 @@ posts_urlpatterns = [
     url(r'(?P<pk>[0-9a-z\\-]+)/edit/$', post_views.post_update, name='posts-update'),
 
     # /posts/aeea8619-a9c1-4792-a273-80ccb7255ea2/delete/
-    url(r'(?P<pk>[0-9a-z\\-]+)/delete/$', post_views.PostDelete.as_view(), name='posts-delete'),
+    url(r'(?P<pk>[0-9a-z\\-]+)/delete/$', post_views.post_delete, name='posts-delete'),
+
 
     # /posts/aeea8619-a9c1-4792-a273-80ccb7255ea2/comment
     url(r'(?P<pk>[0-9a-z\\-]+)/comment/$', post_views.add_comment_to_post, name='add_comment_to_post'),

--- a/social/app/views/post.py
+++ b/social/app/views/post.py
@@ -1,22 +1,18 @@
 import base64
-import uuid
 from itertools import chain
 from operator import attrgetter
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.contrib.auth.views import redirect_to_login
 from django.db.models import Q, F
 from django.http import Http404, HttpResponseRedirect, HttpResponse, HttpResponseForbidden
 from django.shortcuts import render, get_object_or_404, redirect
-from django.urls import reverse_lazy, reverse
+from django.urls import reverse
 from django.views import generic
-from django.views.generic import UpdateView, DeleteView
 
 from social.app.forms.comment import CommentForm
 from social.app.forms.post import TextPostForm, FilePostForm
 from social.app.models.author import Author
-from social.app.models.category import Category
 from social.app.models.comment import Comment
 from social.app.models.node import Node
 from social.app.models.post import Post


### PR DESCRIPTION
Turns out that we had more than one item on a page with the same id... which is NOT cool. 
The delete button works on the correct post now and now the user is redirected to "My Posts" instead of being redirected to "My Feed"