### PR TITLE
Add internal AJAX endpoint documentation; remove session auth from Swagger

### DIFF
--- a/service/internal/authors/views.py
+++ b/service/internal/authors/views.py
@@ -1,138 +1,189 @@
 import urlparse
 
 import requests
-from rest_framework import status
+from rest_framework import status, viewsets
 from rest_framework.authentication import SessionAuthentication
-from rest_framework.decorators import api_view, authentication_classes, permission_classes
+from rest_framework.decorators import api_view, authentication_classes, permission_classes, detail_route
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.reverse import reverse
+from rest_framework.serializers import Serializer
 
 from social.app.models.author import Author
 
 
-@api_view(["POST"], exclude_from_schema=True)
-@authentication_classes((SessionAuthentication,))
-@permission_classes((IsAuthenticated,))
-def follow(request, pk=None):
-    follower = request.user.profile
+class InternalAPIViewSet(viewsets.GenericViewSet):
+    authentication_classes = (SessionAuthentication,)
+    permission_classes = (IsAuthenticated,)
+    serializer_class = Serializer
 
-    if not follower.activated:
+    @detail_route(["POST"])
+    def follow(self, request, pk=None):
+        """
+        Internal endpoint used by the website's Author detail page to allow the currently logged in Author to follow another
+        Author.
+        
+        For local AJAX use only.
+
+        ### Parameters
+        * id: The ID of the author to be followed. (UUID, required)
+        
+        Usage on `/social/app/templates/app/author_detail.html'.
+
+        ### Example Response
+
+            { 
+                "followed_author": "http://site/service/author/62309fbb-72c5-4dce-bf65-4a3bf9b92f09"
+            }
+        """
+        follower = request.user.profile
+
+        if not follower.activated:
+            return Response(
+                {"detail": "Unactivated authors cannot follow other authors."},
+                status=status.HTTP_403_FORBIDDEN)
+
+        try:
+            followee = Author.objects.get(id=pk)
+        except Author.DoesNotExist:
+            return Response(
+                {'detail': 'The author you wanted to follow could not be found.'},
+                status=status.HTTP_404_NOT_FOUND)
+
+        # Does this author already follow followee?
+        if follower.followed_authors.filter(id=followee.id):
+            return Response(
+                {"detail": "You already follow this author."},
+                status=status.HTTP_403_FORBIDDEN)
+
+        if not followee.activated:
+            return Response(
+                {"detail": "Unactivated authors cannot be followed."},
+                status=status.HTTP_403_FORBIDDEN)
+
+        follower.followed_authors.add(followee)
+
         return Response(
-            {"detail": "Unactivated authors cannot follow other authors."},
-            status=status.HTTP_403_FORBIDDEN)
+            {"followed_author": reverse("service:author-detail", kwargs={'pk': followee.id}, request=request)},
+            status=status.HTTP_200_OK)
 
-    try:
-        followee = Author.objects.get(id=pk)
-    except Author.DoesNotExist:
+    @detail_route(["POST"])
+    def unfollow(self, request, pk=None):
+        """
+        Internal endpoint used by the website's Author detail page to allow the currently logged in Author to unfollow another
+        Author.
+        
+        For local AJAX use only.
+        
+        Usage on `/social/app/templates/app/author_detail.html'.
+        
+        ### Parameters
+        * id: The ID of the author to be unfollowed. (UUID, required)
+        
+        ### Example Response
+
+            { 
+                "unfollowed_author": "http://site/service/author/62309fbb-72c5-4dce-bf65-4a3bf9b92f09"
+            }
+        """
+        unfollower = request.user.profile
+
+        if not unfollower.activated:
+            return Response(
+                {"detail": "Unactivated authors cannot unfollow other authors."},
+                status=status.HTTP_403_FORBIDDEN)
+
+        try:
+            followee = Author.objects.get(id=pk)
+        except Author.DoesNotExist:
+            return Response(
+                {'detail': 'The author you wanted to unfollow could not be found.'},
+                status=status.HTTP_404_NOT_FOUND)
+
+        if not followee.activated:
+            return Response(
+                {"detail": "Unactivated authors cannot be unfollowed."},
+                status=status.HTTP_403_FORBIDDEN)
+
+        # Does this author already not follow followee?
+        if not unfollower.followed_authors.filter(id=followee.id):
+            return Response(
+                {"detail": "You already do not follow this author."},
+                status=status.HTTP_403_FORBIDDEN)
+
+        unfollower.followed_authors.remove(followee)
+
         return Response(
-            {'detail': 'The author you wanted to follow could not be found.'},
-            status=status.HTTP_404_NOT_FOUND)
+            {"unfollowed_author": reverse("service:author-detail", kwargs={'pk': followee.id}, request=request)},
+            status=status.HTTP_200_OK)
 
-    # Does this author already follow followee?
-    if follower.followed_authors.filter(id=followee.id):
-        return Response(
-            {"detail": "You already follow this author."},
-            status=status.HTTP_403_FORBIDDEN)
+    @detail_route(["POST"])
+    def friendrequest(self, request, pk=None):
+        """
+        Internal endpoint used by the website's Author detail page to allow the currently logged in Author to send a 
+        friend request to another Author.
+        
+        If the target author is remote, it sends a request to the remote Node's `/friendrequest/` endpoint.
+        
+        For local AJAX use only.
+        
+        Usage on `/social/app/templates/app/author_detail.html'.
+        
+        ### Parameters
+        * id: The ID of the author to be sent a friend request. (UUID, required)
+        
+        ### Example Response
 
-    if not followee.activated:
-        return Response(
-            {"detail": "Unactivated authors cannot be followed."},
-            status=status.HTTP_403_FORBIDDEN)
+            { 
+                "friend_requested_author": "http://site/service/author/62309fbb-72c5-4dce-bf65-4a3bf9b92f09"
+            }
+        """
+        current_author = request.user.profile
 
-    follower.followed_authors.add(followee)
+        if not current_author.activated:
+            return Response(
+                {"detail": "Unactivated authors cannot friend request other authors."},
+                status=status.HTTP_403_FORBIDDEN)
 
-    return Response(
-        {"followed_author": reverse("service:author-detail", kwargs={'pk': followee.id}, request=request)},
-        status=status.HTTP_200_OK)
+        try:
+            # This is triggered by an AJAX call on our website, on an Author's page,
+            # so it's not possible for it to not be in our database unless something unintended is happening
+            target = Author.objects.get(id=pk)
+        except Author.DoesNotExist:
+            return Response(
+                {'detail': 'The author you wanted to friend request could not be found.'},
+                status=status.HTTP_404_NOT_FOUND)
 
+        if current_author.friends.filter(id=target.id):
+            return Response(
+                {"detail": "You are already friends with this author."},
+                status=status.HTTP_403_FORBIDDEN)
 
-@api_view(["POST"], exclude_from_schema=True)
-@authentication_classes((SessionAuthentication,))
-@permission_classes((IsAuthenticated,))
-def unfollow(request, pk=None):
-    unfollower = request.user.profile
+        if current_author.outgoing_friend_requests.filter(id=target.id):
+            return Response(
+                {"detail": "You already have a pending friend request with this author."},
+                status=status.HTTP_403_FORBIDDEN)
 
-    if not unfollower.activated:
-        return Response(
-            {"detail": "Unactivated authors cannot unfollow other authors."},
-            status=status.HTTP_403_FORBIDDEN)
+        if not target.activated:
+            return Response(
+                {"detail": "Unactivated authors cannot be friend requested."},
+                status=status.HTTP_403_FORBIDDEN)
 
-    try:
-        followee = Author.objects.get(id=pk)
-    except Author.DoesNotExist:
-        return Response(
-            {'detail': 'The author you wanted to unfollow could not be found.'},
-            status=status.HTTP_404_NOT_FOUND)
-
-    if not followee.activated:
-        return Response(
-            {"detail": "Unactivated authors cannot be unfollowed."},
-            status=status.HTTP_403_FORBIDDEN)
-
-    # Does this author already not follow followee?
-    if not unfollower.followed_authors.filter(id=followee.id):
-        return Response(
-            {"detail": "You already do not follow this author."},
-            status=status.HTTP_403_FORBIDDEN)
-
-    unfollower.followed_authors.remove(followee)
-
-    return Response(
-        {"unfollowed_author": reverse("service:author-detail", kwargs={'pk': followee.id}, request=request)},
-        status=status.HTTP_200_OK)
-
-
-@api_view(["POST"], exclude_from_schema=True)
-@authentication_classes((SessionAuthentication,))
-@permission_classes((IsAuthenticated,))
-def friendrequest(request, pk=None):
-    current_author = request.user.profile
-
-    if not current_author.activated:
-        return Response(
-            {"detail": "Unactivated authors cannot friend request other authors."},
-            status=status.HTTP_403_FORBIDDEN)
-
-    try:
-        # This is triggered by an AJAX call on our website, on an Author's page,
-        # so it's not possible for it to not be in our database unless something unintended is happening
-        target = Author.objects.get(id=pk)
-    except Author.DoesNotExist:
-        return Response(
-            {'detail': 'The author you wanted to friend request could not be found.'},
-            status=status.HTTP_404_NOT_FOUND)
-
-    if current_author.friends.filter(id=target.id):
-        return Response(
-            {"detail": "You are already friends with this author."},
-            status=status.HTTP_403_FORBIDDEN)
-
-    if current_author.outgoing_friend_requests.filter(id=target.id):
-        return Response(
-            {"detail": "You already have a pending friend request with this author."},
-            status=status.HTTP_403_FORBIDDEN)
-
-    if not target.activated:
-        return Response(
-            {"detail": "Unactivated authors cannot be friend requested."},
-            status=status.HTTP_403_FORBIDDEN)
-
-    if target.node.local:
-        current_author.add_friend_request(target)
-    else:
-        r = target.node.post_friend_request(request, current_author, target)
-
-        if 200 <= r.status_code < 300:
-            # Success!
+        if target.node.local:
             current_author.add_friend_request(target)
         else:
-            return Response(
-                {"detail": "Remote friend request failed."},
-                status=status.HTTP_500_INTERNAL_SERVER_ERROR
-            )
+            r = target.node.post_friend_request(request, current_author, target)
 
-    return Response(
-        {"friend_requested_author": reverse("service:author-detail", kwargs={'pk': target.id},
-                                            request=request)},
-        status=status.HTTP_200_OK)
+            if 200 <= r.status_code < 300:
+                # Success!
+                current_author.add_friend_request(target)
+            else:
+                return Response(
+                    {"detail": "Remote friend request failed."},
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR
+                )
+
+        return Response(
+            {"friend_requested_author": reverse("service:author-detail", kwargs={'pk': target.id},
+                                                request=request)},
+            status=status.HTTP_200_OK)

--- a/service/urls.py
+++ b/service/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url, include
+from rest_framework import routers
 
 import service.authors.views
 import service.friendrequest.views
@@ -30,13 +31,13 @@ author_urls = [
 
 internal_urls = [
     url(r'^author/(?P<pk>[0-9a-fA-F-]+)/follow/?$',
-        service.internal.authors.views.follow,
+        service.internal.authors.views.InternalAPIViewSet.as_view({'post': 'follow'}),
         name='author-follow'),
     url(r'^author/(?P<pk>[0-9a-fA-F-]+)/unfollow/?$',
-        service.internal.authors.views.unfollow,
+        service.internal.authors.views.InternalAPIViewSet.as_view({'post': 'unfollow'}),
         name='author-unfollow'),
     url(r'^author/(?P<pk>[0-9a-fA-F-]+)/friendrequest/?$',
-        service.internal.authors.views.friendrequest,
+        service.internal.authors.views.InternalAPIViewSet.as_view({'post': 'friendrequest'}),
         name='author-friendrequest'),
 ]
 

--- a/social/settings.py
+++ b/social/settings.py
@@ -178,3 +178,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 100
 }
+
+SWAGGER_SETTINGS = {
+    'USE_SESSION_AUTH': False,
+}


### PR DESCRIPTION
Now you can click "Authorize" in the top-right corner and authorize with Basic Auth.

For demo purposes, we can also log in with a username/password we set up on the local node.